### PR TITLE
chore: add dependency review and update gitignore

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,12 @@
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .?*
+!.github
 !.dockerignore
 __pycache__
 **/.DS_Store
@@ -10,3 +11,5 @@ abigenBindings/
 _ixh/
 hmny_wallets/
 tmp/
+devnet/docker/icon-bsc/local/
+devnet/docker/icon-bsc/data/


### PR DESCRIPTION
Dependency review action raise an error if any dependency vulnerabilities are introduced. Gitignore no longer ignores .github and now ignores local and data files generated by icon-bsc build steps.

Closes #453